### PR TITLE
The default dir for the test runner is test-runner in lsp-java

### DIFF
--- a/dap-java.el
+++ b/dap-java.el
@@ -38,7 +38,7 @@ If the port is taken, DAP will try the next port."
   :type 'number)
 
 (defcustom dap-java-test-runner
-  (expand-file-name (locate-user-emacs-file "eclipse.jdt.ls/runner/junit-platform-console-standalone.jar"))
+  (expand-file-name (locate-user-emacs-file "eclipse.jdt.ls/test-runner/junit-platform-console-standalone.jar"))
   "DAP Java test runner."
   :group 'dap-java-java
   :type 'file)


### PR DESCRIPTION
I'm basing this on https://github.com/emacs-lsp/lsp-java/blob/bfab7a684152d6d424708221fa1200dff7edfc20/lsp-java.el#L527

Whereas in dap-java, we are looking for a directory called `runner`