### PR TITLE
Fix an error with repl completions in python

### DIFF
--- a/dap-ui-repl.el
+++ b/dap-ui-repl.el
@@ -109,8 +109,9 @@ TEXT is the current input."
 (defun dap-ui-repl--post-completion (candidate)
   "Post completion handling for CANDIDATE."
   (let ((to-insert (plist-get (text-properties-at 0 candidate) :text)))
-    (delete-char (- (length candidate)))
-    (insert to-insert)))
+    (when to-insert
+      (delete-char (- (length candidate)))
+      (insert to-insert))))
 
 (defun dap-ui-repl--annotate (candidate)
   "Get annotation for CANDIDATE."


### PR DESCRIPTION
There was an error after selecting a candidate:
```company-call-backend-raw: Company: backend company-dap-ui-repl error
"Wrong type argument: char-or-string-p, nil" with args (post-completion long_name)```
