### PR TITLE
Two small code fixes

### DIFF
--- a/dap-mode.el
+++ b/dap-mode.el
@@ -31,6 +31,8 @@
 (require 'f)
 (require 'dash)
 (require 'dap-overlays)
+(eval-when-compile
+  (require 'cl))
 
 (defconst dap--breakpoints-file (expand-file-name (locate-user-emacs-file ".dap-breakpoints"))
   "Name of the file in which the breakpoints will be persisted.")

--- a/dap-mode.el
+++ b/dap-mode.el
@@ -932,7 +932,6 @@ should be started after the :port argument is taken.
 
     (unless skip-debug-session
       (let ((debug-session (dap--create-session launch-args))
-            (workspace lsp--cur-workspace)
             (breakpoints (dap--get-breakpoints)))
         (dap--send-message
          (dap--initialize-message type)


### PR DESCRIPTION
This PR does the following:

- Remove an unused `workspace` let binding.
- Require `cl` in `dap-mode`, as it uses `first` and `rest` and a user may receive a `Symbol's function definition is void: first` error message when running `dap-debug` otherwise.