### PR TITLE
Remove duplicate link to DAP page in README

### DIFF
--- a/README.org
+++ b/README.org
@@ -30,9 +30,10 @@
 
 * Summary
   Emacs client/library for [[https://code.visualstudio.com/docs/extensionAPI/api-debugging][Debug Adapter Protocol]]
-  [[https://code.visualstudio.com/docs/extensionAPI/api-debugging][Debug Adapter Protocol]] is a wire protocol for communication between client and
-  Debug Server. It similar to the [[https://github.com/Microsoft/language-server-protocol][LSP]] but providers integration with debug
-  server.
+  is a wire protocol for communication between client and Debug Server. It's
+  similar to the [[https://github.com/Microsoft/language-server-protocol][LSP]]
+  but providers integration with debug server.
+
   *Note: dap-mode works only against lsp.el interface.*
 ** Project status
    The project is in it's early stage and is still not extensively tested. The


### PR DESCRIPTION
Also, s/It similar/It's similar/ and add the note about requiring lsp
mode to separate line.

Every contribution counts :)