### PR TITLE
Add a variable to get the debug file path 

### DIFF
--- a/dap-lldb.el
+++ b/dap-lldb.el
@@ -34,13 +34,20 @@
   :group 'dap-lldb
   :type '(repeat string))
 
+(defcustom dap-lldb-debugged-program-function 'buffer-file-name
+  "The function to get the path of the file to be debugged."
+  :group 'dap-lldb
+  :type 'symbol)
+
 (defun dap-lldb--populate-start-file-args (conf)
   "Populate CONF with the required arguments."
   (-> conf
       (dap--put-if-absent :dap-server-path dap-lldb-debug-program)
       (dap--put-if-absent :type "lldb")
       (dap--put-if-absent :cwd default-directory)
-      (dap--put-if-absent :program (buffer-file-name))
+      (dap--put-if-absent :program (if (commandp dap-lldb-debugged-program-function)
+                                       (call-interactively dap-lldb-debugged-program-function)
+                                     (funcall dap-lldb-debugged-program-function)))
       (dap--put-if-absent :name "LLDB Debug")))
 
 (eval-after-load "dap-mode"


### PR DESCRIPTION
Hello
It is not work to get the path of debugging file with `buffer-file-name` in c/c++ mode.So I added a variable to let the user customize the function.