### PR TITLE
Preliminary support for felixbecker/vscode-php-debug

### DIFF
--- a/README.org
+++ b/README.org
@@ -28,6 +28,7 @@
   - [[#lldb][LLDB]]
     - [[#installation-2][Installation]]
   - [[#elixir][Elixir]]
+  - [[#php][PHP]]
 - [[#extending-dap-with-new-debug-servers][Extending DAP with new Debug servers]]
     - [[#example][Example]]
 - [[#links][Links]]
@@ -198,6 +199,16 @@ LLDB is a debugger that supports, among others, C, C++, Objective-C and Swift.
    Then when you do ~dap-debug-edit-template~ and select Elixir which will
    generate runnable debug configuration. For more details on supported settings
    by the Elixir Debug Server refer to it's documentation.
+** PHP
+   This is using [[https://github.com/felixfbecker/vscode-php-debug][felixbecker/vscode-php-debug]] as dap-server between
+   emacs and the xdebug-extension on the http-server side. Make sure it is trans/compiled to javascript properly. Only tested 
+   under linux with node.
+     #+BEGIN_SRC elisp
+       (require 'dap-php)
+     #+END_SRC
+   The default project location is passed as ~projectile-project-root~, make sure you adapt all settings to your circumstances.
+   To begin debugging, select "PHP Run Configuration" from the `dap-debug` menu, issue the debug request in your browser, 
+   select the running thread (~dap-switch-thread`) and then ~dap-step-in~.
 * Extending DAP with new Debug servers
   There are two methods that are used for registering remote extensions:
   - ~dap-register-debug-provider~ - register a method to call for populating

--- a/README.org
+++ b/README.org
@@ -200,9 +200,10 @@ LLDB is a debugger that supports, among others, C, C++, Objective-C and Swift.
    generate runnable debug configuration. For more details on supported settings
    by the Elixir Debug Server refer to it's documentation.
 ** PHP
-   This is using [[https://github.com/felixfbecker/vscode-php-debug][felixbecker/vscode-php-debug]] as dap-server between
-   emacs and the xdebug-extension on the http-server side. Make sure it is trans/compiled to javascript properly. Only tested 
-   under linux with node.
+   This is using [[https://github.com/felixfbecker/vscode-php-debug][felixbecker/vscode-php-debug]]
+   ([[https://marketplace.visualstudio.com/items?itemName=felixfbecker.php-debug][downloadable from the marketplace]])
+   as dap-server between emacs and the xdebug-extension on the http-server side. Make sure it is trans/compiled to 
+   javascript properly. Only tested under linux with node.
      #+BEGIN_SRC elisp
        (require 'dap-php)
      #+END_SRC

--- a/dap-php.el
+++ b/dap-php.el
@@ -40,7 +40,7 @@
   (-> conf
       (dap--put-if-absent :dap-server-path dap-php-debug-program)
       (dap--put-if-absent :type "node")
-      (dap--put-if-absent :cwd projectile-project-root)
+      (dap--put-if-absent :cwd (lsp-find-session-root))
       (dap--put-if-absent :name "Php Debug")))
 
 (dap-register-debug-provider "php" 'dap-php--populate-start-file-args)

--- a/dap-php.el
+++ b/dap-php.el
@@ -1,0 +1,57 @@
+;;; dap-php.el --- Debug Adapter Protocol mode for Php      -*- lexical-binding: t; -*-
+
+;; Copyright (C) 2018  Ivan Yonchovski
+
+;; Author: Ivan Yonchovski <yyoncho@gmail.com>
+;; Author: Thomas Regner <tom@tomsdiner.org>
+;; Keywords: languages
+
+;; This program is free software; you can redistribute it and/or modify
+;; it under the terms of the GNU General Public License as published by
+;; the Free Software Foundation, either version 3 of the License, or
+;; (at your option) any later version.
+
+;; This program is distributed in the hope that it will be useful,
+;; but WITHOUT ANY WARRANTY; without even the implied warranty of
+;; MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+;; GNU General Public License for more details.
+
+;; You should have received a copy of the GNU General Public License
+;; along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+;; URL: https://github.com/yyoncho/dap-mode
+;; Package-Requires: ((emacs "25.1") (dash "2.14.1") (lsp-mode "4.0"))
+;; Version: 0.2
+
+;;; Commentary:
+;; Adapter for https://github.com/felixfbecker/vscode-php-debug
+
+;;; Code:
+
+(require 'dap-mode)
+
+(defcustom dap-php-debug-program `("node" ,(expand-file-name "~/.extensions/php/out/phpDebug.js"))
+  "The path to the php debugger."
+  :group 'dap-php
+  :type '(repeat string))
+
+(defun dap-php--populate-start-file-args (conf)
+  "Populate CONF with the required arguments."
+  (-> conf
+      (dap--put-if-absent :dap-server-path dap-php-debug-program)
+      (dap--put-if-absent :type "node")
+      (dap--put-if-absent :cwd projectile-project-root)
+      (dap--put-if-absent :name "Php Debug")))
+
+(dap-register-debug-provider "php" 'dap-php--populate-start-file-args)
+(dap-register-debug-template "Php Run Configuration"
+                             (list :type "node"
+                                   :cwd nil
+                                   :request "launch"
+                                   :name "Php Debug"
+                                   :args '("--server=4711")
+                                   :sourceMaps t
+                                   ))
+
+(provide 'dap-php)
+;;; dap-php.el ends here

--- a/dap-php.el
+++ b/dap-php.el
@@ -40,7 +40,7 @@
   (-> conf
       (dap--put-if-absent :dap-server-path dap-php-debug-program)
       (dap--put-if-absent :type "node")
-      (dap--put-if-absent :cwd (lsp-find-session-root))
+      (dap--put-if-absent :cwd (lsp-find-session-folder (lsp-session) (buffer-file-name)))
       (dap--put-if-absent :name "Php Debug")))
 
 (dap-register-debug-provider "php" 'dap-php--populate-start-file-args)


### PR DESCRIPTION
This works only  'kind-of'; sessions-list shows weird behaviour; company-completion in repl does not work; and a few other minor things.

But I can debug with xdebug :) 

 I have my setup so that I don't need a path-mapping, paths are equal remote/local, but it should be easy to add to the debug template.