### PR TITLE
Fix typo in README.org

### DIFF
--- a/README.org
+++ b/README.org
@@ -39,7 +39,7 @@
 * Summary
   Emacs client/library for [[https://code.visualstudio.com/docs/extensionAPI/api-debugging][Debug Adapter Protocol]] is a wire protocol for
   communication between client and Debug Server. It's similar to the [[https://github.com/Microsoft/language-server-protocol][LSP]] but
-  providers integration with debug server.
+  provides integration with debug server.
 
   *Note: dap-mode works only against lsp.el interface.*
 ** Project status


### PR DESCRIPTION
Fix typo in README.org: s/providers/provides