### PR TITLE
dap-mode.el: use cl-lib instead of cl

### DIFF
--- a/dap-java.el
+++ b/dap-java.el
@@ -76,7 +76,7 @@ If the port is taken, DAP will try the next port."
     (cond
      ((= main-classes-count 0) (error "Unable to find main class.
 Please check whether the server is configured propertly"))
-     ((= main-classes-count 1) (first main-classes))
+     ((= main-classes-count 1) (cl-first main-classes))
      ((setq current-class (--first (string= buffer-file-name (gethash "filePath" it))
                                    main-classes))
       current-class)
@@ -106,7 +106,7 @@ Please check whether the server is configured propertly"))
     (dap--put-if-absent conf :modulePaths (vector))
     (dap--put-if-absent conf
                         :classPaths
-                        (or (second
+                        (or (cl-second
                              (lsp-send-execute-command "vscode.java.resolveClasspath"
                                                        (list main-class project-name)))
                             (error "Unable to resolve classpath")))
@@ -178,15 +178,15 @@ test."
   (-let* ((to-run (->> (list :cursorOffset (point)
                              :sourceUri (lsp--path-to-uri (buffer-file-name)))
                        (lsp-send-execute-command "che.jdt.ls.extension.findTestByCursor")
-                       first))
-          (test-class-name (first (s-split "#" to-run)))
+                       cl-first))
+          (test-class-name (cl-first (s-split "#" to-run)))
           (class-path (->> (list test-class-name nil)
                            (lsp-send-execute-command "vscode.java.resolveClasspath")
-                           second
+                           cl-second
                            (s-join dap-java--classpath-separator))))
     (message "CLASSPATH: %s " class-path)
     (list :program-to-start (s-join " "
-                                    (list* runner "-jar" dap-java-test-runner
+                                    (cl-list* runner "-jar" dap-java-test-runner
                                            "-cp" (format dap-java--var-format "JUNIT_CLASS_PATH")
                                            (if (and (s-contains? "#" to-run) run-method?) "-m" "-c")
                                            (if run-method? to-run test-class-name)

--- a/dap-mode.el
+++ b/dap-mode.el
@@ -31,7 +31,7 @@
 (require 'f)
 (require 'dash)
 (require 'dap-overlays)
-(require 'cl)
+(require 'cl-lib)
 
 (defconst dap--breakpoints-file (expand-file-name (locate-user-emacs-file ".dap-breakpoints"))
   "Name of the file in which the breakpoints will be persisted.")
@@ -262,7 +262,7 @@ TRANSFORM-FN will be used to transform each of the items before displaying.
 PROMPT COLLECTION PREDICATE REQUIRE-MATCH INITIAL-INPUT HIST DEF
 INHERIT-INPUT-METHOD will be proxied to `completing-read' without changes."
   (let* ((result (--map (cons (funcall transform-fn it) it) collection))
-         (completion (completing-read prompt (-map 'first result)
+         (completion (completing-read prompt (-map 'cl-first result)
                                       predicate require-match initial-input hist
                                       def inherit-input-method)))
     (cdr (assoc completion result))))
@@ -272,8 +272,8 @@ INHERIT-INPUT-METHOD will be proxied to `completing-read' without changes."
 This is in contrast to merely setting it to 0."
   (let (p)
     (while plist
-      (if (not (eq property (first plist)))
-          (setq p (plist-put p (first plist) (nth 1 plist))))
+      (if (not (eq property (cl-first plist)))
+          (setq p (plist-put p (cl-first plist) (nth 1 plist))))
       (setq plist (cddr plist)))
     p))
 
@@ -637,7 +637,7 @@ thread exection but the server will log message."
       ;; thread-id is the same as the active one
       (when (and (eq debug-session (dap--cur-session))
                  (= thread-id (dap--debug-session-thread-id (dap--cur-session))))
-        (dap--go-to-stack-frame debug-session (first stack-frames)))))
+        (dap--go-to-stack-frame debug-session (cl-first stack-frames)))))
    debug-session))
 
 (defun dap--buffer-list ()
@@ -985,7 +985,7 @@ should be started after the :port argument is taken.
   "Read FILE content."
   (with-temp-buffer
     (insert-file-contents-literally file)
-    (first (read-from-string
+    (cl-first (read-from-string
             (buffer-substring-no-properties (point-min) (point-max))))))
 
 (defun dap--after-initialize ()
@@ -1121,8 +1121,8 @@ CONFIGURATION-SETTINGS - plist containing the preset settings for the configurat
   "Select the configuration to launch."
   (let ((debug-args (-> (dap--completing-read "Select configuration template: "
                                               dap--debug-template-configurations
-                                              'first nil t)
-                        rest
+                                              'cl-first nil t)
+                        cl-rest
                         copy-tree)))
     (or (-some-> (plist-get debug-args :type)
                  (gethash dap--debug-providers)
@@ -1137,8 +1137,8 @@ If DEBUG-ARGS is not specified the configuration is generated
 after selecting configuration template."
   (interactive (list (-> (dap--completing-read "Select configuration template: "
                                                dap--debug-template-configurations
-                                               'first nil t)
-                         rest
+                                               'cl-first nil t)
+                         cl-rest
                          copy-tree)))
   (dap-start-debugging (or (-some-> (plist-get debug-args :type)
                                     (gethash dap--debug-providers)
@@ -1158,7 +1158,7 @@ after selecting configuration template."
     (-let ((column (current-column))
            ((fst snd . rst) debug-args))
       (insert (format "%s %s" fst (prin1-to-string snd)))
-      (loop for (k v) on rst by (function cddr)
+      (cl-loop for (k v) on rst by (function cddr)
             do (progn
                  (insert "\n")
                  (--dotimes column (insert " "))
@@ -1169,7 +1169,7 @@ after selecting configuration template."
 (defun dap-debug-last ()
   "Debug last configuration."
   (interactive)
-  (if-let (configuration (cdr (first dap--debug-configuration)))
+  (if-let (configuration (cdr (cl-first dap--debug-configuration)))
       (dap-debug configuration)
     (funcall-interactively 'dap-debug-select-configuration)))
 
@@ -1178,8 +1178,8 @@ after selecting configuration template."
   (interactive)
   (->> (dap--completing-read "Select configuration: "
                              dap--debug-configuration
-                             'first nil t)
-       rest
+                             'cl-first nil t)
+       cl-rest
        dap-debug))
 
 (defun dap-go-to-output-buffer ()

--- a/dap-ui.el
+++ b/dap-ui.el
@@ -232,7 +232,7 @@
   (if-let (widget (dap-ui-sessions--tree-under-cursor))
       (-let ((session (widget-get widget :session))
              (dap-ui-session-refresh-delay nil))
-        (case (widget-get widget :element-type)
+        (cl-case (widget-get widget :element-type)
           (:session (dap--switch-to-session session))
           (:thread (-let ((thread  (widget-get widget :thread)))
                      (setf (dap--debug-session-thread-id session) (gethash "id" thread) )
@@ -512,7 +512,7 @@ E is the ending of the overlay.
 VISUALS and MSG will be used for the overlay."
   (let ((beg b)
         (end e))
-    (assert (and
+    (cl-assert (and
              file
              (or (integerp point)
                  (and (integerp beg)
@@ -677,7 +677,7 @@ DEBUG-SESSION is the active debug session."
       (or (widget-get tree :variables)
           (progn (dap--send-message
                   (dap--make-request "variables"
-                                     (list* :variablesReference variables-reference
+                                     (cl-list* :variablesReference variables-reference
                                             (when (and indexed-variables
                                                        (< dap-ui-default-fetch-count indexed-variables ))
                                               (list :start 0
@@ -735,7 +735,7 @@ DEBUG-SESSION is the active debug session."
                                             (or (-> buf
                                                     buffer-name
                                                     (assoc dap-ui-buffer-configurations)
-                                                    rest)
+                                                    cl-rest)
                                                 '((side . right)
                                                   (slot . 1)
                                                   (window-width . 0.20))))))
@@ -903,10 +903,10 @@ REQUEST-ID is the active request id. If it doesn't maches the
 
 (defun dap-ui--get-file-info (file-data &optional _)
   "Used to render FILE-DATA in breakpoints' list."
-  (list (f-filename (first file-data))
+  (list (f-filename (cl-first file-data))
         :type 'dap-ui-breakpoint-position
-        'file (first file-data)
-        'point (second file-data)))
+        'file (cl-first file-data)
+        'point (cl-second file-data)))
 
 (bui-define-interface dap-ui-breakpoints-ui list
   :buffer-name "*Breakpoints*"
@@ -942,7 +942,7 @@ REQUEST-ID is the active request id. If it doesn't maches the
   "Delete breakpoint on the current line."
   (interactive)
   (->> (bui-list-get-marked 'general)
-       (-map 'first)
+       (-map 'cl-first)
        (bui-entries-by-ids (bui-current-entries))
        (-map 'dap-ui-breakpoints-delete)))
 


### PR DESCRIPTION
In order to solve #44 and (some problem of) #44 , https://github.com/yyoncho/dap-mode/commit/ebb34c394067c81e29a36dc71452f326319a782d introduces `(require 'cl)` outside of `eval-when-compile`, which causes complain from linter.

[Emacs recommands](https://www.gnu.org/software/emacs/manual/html_mono/cl.html#Organization) `cl-lib` instead of `cl` for new packages. However, functions provided by `cl-lib` are prefixed with 'cl-' (which provides some kind of namespace), so switching to `cl-lib` requires prepending this prefix to functions from `cl`.

After changing `cl` to `cl-lib` (restart emacs, `features` shows that `cl` is not loaded), all unknown symbols ( `first`, `second`, `rest`, `for`, `let*`) reported by `byte-recompile-directory` are changed to their `cl-lib` counterpart (`cl-first`, `cl-second`, `cl-rest`, `cl-for`, `cl-let*`).